### PR TITLE
fix: Revert provenance changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "@icons-pack/svelte-simple-icons",
 	"version": "4.0.1",
 	"publishConfig": {
-		"provenance": true,
 		"access": "public"
 	},
 	"engines": {


### PR DESCRIPTION
Revert the provenance changes to unblock releases. The GITHUB_TOKEN permission issue needs to be investigated.