### PR TITLE
feat: Bump simple icons to 16.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # svelte-simple-icons
 
-This package provides the [Simple Icons 16.12.0](https://github.com/simple-icons/simple-icons/releases/tag/16.12.0) packaged as a set of [Svelte](https://svelte.dev/) components.
+This package provides the [Simple Icons 16.16.0](https://github.com/simple-icons/simple-icons/releases/tag/16.16.0) packaged as a set of [Svelte](https://svelte.dev/) components.
 
   <a href="https://www.npmjs.com/package/@icons-pack/svelte-simple-icons" target="_blank">
     <img src="https://img.shields.io/npm/v/@icons-pack/svelte-simple-icons?color=CB061D&style=flat-square" alt="www.npmjs.com!" />

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@sveltejs/package": "2.5.7",
 		"@sveltejs/vite-plugin-svelte": "6.2.4",
 		"signale": "1.4.0",
-		"simple-icons": "16.12.0",
+		"simple-icons": "16.16.0",
 		"svelte": "5.50.1",
 		"svelte-check": "4.3.6",
 		"tslib": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       simple-icons:
-        specifier: 16.12.0
-        version: 16.12.0
+        specifier: 16.16.0
+        version: 16.16.0
       svelte:
         specifier: 5.50.1
         version: 5.50.1
@@ -988,8 +988,8 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
-  simple-icons@16.12.0:
-    resolution: {integrity: sha512-fDJDqXUpkb2twqH+eBQpJsCYUE6jEH7VkuuPL9dH16sbLf6KKnwyijULmcx7SCoy3c2L6pl8WCzt+4rpYjoWfw==}
+  simple-icons@16.16.0:
+    resolution: {integrity: sha512-H+Z29a0TrCw6mrG42V2aqHQaKdJCT87x5aojLlPiIXOf1lpMqnKFAR/jP5xkI5hLrVTCBWs33e9sOtyNWqCx1A==}
     engines: {node: '>=0.12.18'}
 
   sirv@3.0.2:
@@ -2007,7 +2007,7 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-icons@16.12.0: {}
+  simple-icons@16.16.0: {}
 
   sirv@3.0.2:
     dependencies:


### PR DESCRIPTION
I need the TypeScript component which does not seem to be available in 16.12.0